### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/potty/react-anchorme/security/code-scanning/2](https://github.com/potty/react-anchorme/security/code-scanning/2)

To fix the problem, explicitly declare a `permissions` block and restrict the `GITHUB_TOKEN` to the least privilege needed. This workflow only checks out code and runs local commands; it does not appear to need any write permissions. The minimal safe configuration is `contents: read` at the workflow level, which will apply to all jobs unless overridden.

The single best fix without changing existing functionality is:
- Add a `permissions` section near the top of `.github/workflows/tests.yml`, alongside `name` and `on`, setting `contents: read`.
- No other steps or behavior need to change, because read access is sufficient for `actions/checkout` and for the job’s commands (`pnpm install`, `lint:check`, `test`, `build`).

Concretely:
- Edit `.github/workflows/tests.yml`.
- Insert the `permissions` block after the `name: Tests` line (line 1) and before the `on:` block (line 3).
- No imports or additional definitions are required in a YAML workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
